### PR TITLE
Remove next underscore

### DIFF
--- a/scripts/buildDocs.sh
+++ b/scripts/buildDocs.sh
@@ -17,10 +17,3 @@ yarn next build
 
 # Generate static assets for the docs
 yarn next export
-
-# Move serve.json into the out/ directory to prevent the serve package from
-# redirecting paths with .html appended at the end.
-# (This is only used for development where we use the "serve" package to serve
-# static HTML files)
-# https://github.com/vercel/serve-handler#cleanurls-booleanarray
-cp serve.json out/serve.json

--- a/scripts/buildDocs.sh
+++ b/scripts/buildDocs.sh
@@ -18,21 +18,9 @@ yarn next build
 # Generate static assets for the docs
 yarn next export
 
-# Rename generated out/_next folder to out/next because GitHub Pages
-# does not serve folders that begin with an _
-mv out/_next out/next
-
 # Move serve.json into the out/ directory to prevent the serve package from
 # redirecting paths with .html appended at the end.
 # (This is only used for development where we use the "serve" package to serve
 # static HTML files)
 # https://github.com/vercel/serve-handler#cleanurls-booleanarray
 cp serve.json out/serve.json
-
-# Find and replace all references of _next/ to next/ in all of the assets
-# Note, using sed -i '' will only work on Mac, so remove -i '' to support Ubuntu
-if [ `uname -s` = "Darwin" ]; then
-  find out -type f -name "*.html" -print0 | xargs -0 sed -i '' 's/_next/next/g'
-else
-  find out -type f -name "*.html" -print0 | xargs -0 sed -i 's/_next/next/g'
-fi

--- a/serve.json
+++ b/serve.json
@@ -1,3 +1,0 @@
-{
-  "cleanUrls": false
-}


### PR DESCRIPTION
We used a script to rename the `_next` directory to `next` because the GitHub Pages workflow was not serving or copying the files over. Now that we add a `.nojekyll` file, we no longer need to do this.